### PR TITLE
[feat][frontend] Try to setup development proxy

### DIFF
--- a/gateway/src/main/resources/application-docker.yml
+++ b/gateway/src/main/resources/application-docker.yml
@@ -34,3 +34,9 @@ spring:
             - Path=/threads/**
           filters:
             - StripPrefix=1
+        - id: frontend-dev
+          uri: http://${DOCKER_GATEWAY_HOST:host.docker.internal}:8084
+          predicates:
+            - Path=/frontend-dev/**
+          filters:
+            - StripPrefix=1


### PR DESCRIPTION
> If you are running this stack on Linux you need to have the DOCKER_GATEWAY_HOST environment variable set for the Docker gateway host. Simply put this line into your .bashrc (.bash_profile or .zshrc):
```
export DOCKER_GATEWAY_HOST=172.17.0.1
```