### PR TITLE
KC listen for ersms events (register)

### DIFF
--- a/accounts/src/main/kotlin/pl/edu/pw/ia/accounts/application/AccountController.kt
+++ b/accounts/src/main/kotlin/pl/edu/pw/ia/accounts/application/AccountController.kt
@@ -11,7 +11,6 @@ import java.util.UUID
 import org.axonframework.extensions.reactor.commandhandling.gateway.ReactorCommandGateway
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -21,9 +20,7 @@ import org.springframework.web.bind.annotation.RestController
 import pl.edu.pw.ia.accounts.application.model.CreateAccountRequest
 import pl.edu.pw.ia.shared.application.exception.ApiErrorResponse
 import pl.edu.pw.ia.shared.application.model.IdResponse
-import pl.edu.pw.ia.shared.config.getLogger
 import pl.edu.pw.ia.shared.domain.exception.ClientRequestException
-import pl.edu.pw.ia.shared.security.Scopes
 import reactor.core.publisher.Mono
 
 @Tag(name = "Accounts")
@@ -56,8 +53,8 @@ class AccountControllerImpl(
 	override fun createAccount(
 		@RequestBody request: CreateAccountRequest
 	): Mono<IdResponse> {
-		if (request.operationType != "CREATE" || request.resourceType != "USER") {
-			return Mono.error(ClientRequestException("Endpoint only supports operationType=CREATE and resourceType=USER"))
+		if (request.type != "REGISTER") {
+			return Mono.error(ClientRequestException("Endpoint only supports type=REGISTER"))
 		}
 		val command = request.toCommand()
 		return reactorCommandGateway.send<UUID>(command)

--- a/accounts/src/main/kotlin/pl/edu/pw/ia/accounts/application/model/CreateAccountRequest.kt
+++ b/accounts/src/main/kotlin/pl/edu/pw/ia/accounts/application/model/CreateAccountRequest.kt
@@ -11,38 +11,22 @@ data class CreateAccountRequest(
 
 	@Schema
 	@field:NotNull
-	val representation: String,
+	val details: CreateAccountRequestInner,
 
 	@Schema(maxLength = 50)
-	@field:NotBlank(message = "operationType cannot be blank")
-	@field:Length(max = 50, message = "Maximum allowed operationType length is 50 characters")
-	val operationType: String,
+	@field:NotBlank(message = "type cannot be blank")
+	@field:Length(max = 50, message = "Maximum allowed type length is 50 characters")
+	val type: String,
 
-	@Schema(maxLength = 50)
-	@field:NotBlank(message = "resourceType cannot be blank")
-	@field:Length(max = 50, message = "Maximum allowed resourceType length is 50 characters")
-	val resourceType: String,
-
-	@Schema(maxLength = 100)
-	@field:NotBlank(message = "resourcePath cannot be blank")
-	@field:Length(max = 100, message = "Maximum allowed resourcePath length is 100 characters")
-	val resourcePath: String,
+	@Schema
+	@field:NotNull
+	val userId: UUID,
 ) {
 	fun toCommand(): CreateAccountCommand {
-		// for some reason representation is passed flat in a string
-		// I could not manage to deserialize it, for now I will extract the 2 required fields with regex
-		val representationCleaned = representation.replace("\\", "")
-
-		val usernameRegex = """(?<="username":")[^"]*""".toRegex()
-		val username = usernameRegex.find(representationCleaned)!!.groups[0]!!.value
-
-		val emailRegex = """(?<="email":")[^"]*""".toRegex()
-		val email = emailRegex.find(representationCleaned)!!.groups[0]!!.value
-
 		return CreateAccountCommand(
-			accountId = UUID.fromString(resourcePath.replace("users/", "")),
-			name = username,
-			email = email,
+			accountId = userId,
+			name = details.username,
+			email = details.email,
 		)
 	}
 }

--- a/accounts/src/main/kotlin/pl/edu/pw/ia/accounts/application/model/CreateAccountRequestInner.kt
+++ b/accounts/src/main/kotlin/pl/edu/pw/ia/accounts/application/model/CreateAccountRequestInner.kt
@@ -1,0 +1,20 @@
+package pl.edu.pw.ia.accounts.application.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import org.hibernate.validator.constraints.Length
+
+data class CreateAccountRequestInner(
+
+	@Schema(maxLength = 50)
+	@field:NotBlank(message = "Name cannot be blank")
+	@field:Length(max = 50, message = "Maximum allowed name length is 50 characters")
+	val username: String,
+
+	@Schema(maxLength = 320)
+	@field:Email
+	@field:NotBlank(message = "Email cannot be blank")
+	@field:Length(max = 50, message = "Maximum allowed email length is 320 characters")
+	val email: String,
+)

--- a/keycloak/setup_scripts.sql
+++ b/keycloak/setup_scripts.sql
@@ -6,4 +6,4 @@ VALUES ('_providerConfig.ext-event-http.0',
 		'{"targetUri": "https://accounts-service.ersms-forum.svc.cluster.local:8081/accounts/api/v1/accounts"}',
 		(SELECT id
 		 FROM realm
-		 WHERE name = 'master'));
+		 WHERE name = 'ersms'));


### PR DESCRIPTION
Before the `ext-event-http` was setup to listen to `master` events, for some reason creating users in admin panel is a `master` event. 

Changing the script realm to `ersms` now e.g. github register sends an event. 

For some reason the message format is also different.